### PR TITLE
Add utils.text.as_text function for forcing strings to be "text"

### DIFF
--- a/ostrich/__init__.py
+++ b/ostrich/__init__.py
@@ -1,4 +1,4 @@
 
 __author__ = 'Itamar Ostricher'
-__version__ = '0.0.0.dev2'
+__version__ = '0.0.0.dev4'
 __oneliner__ = 'Ostrich Lib - A Bunch of Simple Useful Stuff'

--- a/ostrich/utils/text.py
+++ b/ostrich/utils/text.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+# Python 2 / Python 3 compatibility fu
+# http://python-future.org/compatible_idioms.html
+from __future__ import absolute_import
+from __future__ import unicode_literals  # so strings without u'' are unicode
+
+# uniform unicode type across Python's
+from builtins import str as text  # from "future" library
 
 import re
 import unicodedata
@@ -8,6 +14,22 @@ import unicodedata
 
 _SAFE_PATH_RE = re.compile(r'[^a-zA-Z0-9\-\_\=\.]')
 _MAX_PATH_NAME_LEN = 255
+
+
+def as_text(str_or_bytes, encoding='utf-8', errors='strict'):
+    """Return input string as a text string.
+
+    Should work for input string that's unicode or bytes,
+    given proper encoding.
+
+    >>> print(as_text(b'foo'))
+    foo
+    >>> b'foo'.decode('utf-8') == u'foo'
+    True
+    """
+    if isinstance(str_or_bytes, text):
+        return str_or_bytes
+    return str_or_bytes.decode(encoding, errors)
 
 
 def get_safe_path(in_str):
@@ -32,7 +54,7 @@ def get_safe_path(in_str):
     True
     """
     norm_str = _SAFE_PATH_RE.sub(
-        '_', unicodedata.normalize('NFKD', in_str).strip())
+        '_', unicodedata.normalize('NFKD', as_text(in_str)).strip())
     if len(norm_str.strip('.')) == 0:
         # making sure the normalized result is non-empty, and not just dots
         raise ValueError(in_str)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     url='https://github.com/TheOstrichIO/ostrichlib',
     description=ostrich.__oneliner__,
     packages=find_packages(),
+    install_requires=['future'],
     setup_requires=['pytest-runner'],
     extras_require={
         'test': ['pytest', 'pytest-cov', 'pytest-pep8'],

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -25,6 +25,10 @@ def test_safe_path_unicode():
             get_safe_path('foo1/b_a-r:baz@m.o=o \u00f6 עוגי'))
 
 
+def test_safe_path_bytes():
+    assert 'foo.bar' == get_safe_path(b'foo.bar')
+
+
 def test_safe_path_no_traversal():
     assert '.._.._.._etc_passwd' == get_safe_path('../../../etc/passwd')
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,4 @@ envlist = py26, py27, py33, py34, py35, pypy, jython
 commands = py.test
 deps =
     pytest
+    future


### PR DESCRIPTION
Adding "future" as a requirement, to simplify Python 2 / Python 3 compatibility...
